### PR TITLE
Fix defaults for Ubuntu 18.04

### DIFF
--- a/wireguard/osfingermap.yaml
+++ b/wireguard/osfingermap.yaml
@@ -16,8 +16,7 @@ Debian-9: {}
 Debian-8: {}
 
 # os: Ubuntu
-Ubuntu-18.04:
-  config: /etc/wireguard.d/custom-ubuntu-18.04.conf
+Ubuntu-18.04: {}
 Ubuntu-16.04: {}
 
 # os: Fedora

--- a/wireguard/osmap.yaml
+++ b/wireguard/osmap.yaml
@@ -14,7 +14,6 @@
 Ubuntu:
   pkg:
     name: wireguard
-#  config: /etc/wireguard.d/custom-ubuntu.conf
 Raspbian: {}
 
 # os_family: RedHat

--- a/wireguard/osmap.yaml
+++ b/wireguard/osmap.yaml
@@ -13,7 +13,7 @@
 # os_family: Debian
 Ubuntu:
   pkg:
-    name: wireguard-ubuntu
+    name: wireguard
   config: /etc/wireguard.d/custom-ubuntu.conf
 Raspbian: {}
 

--- a/wireguard/osmap.yaml
+++ b/wireguard/osmap.yaml
@@ -14,7 +14,7 @@
 Ubuntu:
   pkg:
     name: wireguard
-  config: /etc/wireguard.d/custom-ubuntu.conf
+#  config: /etc/wireguard.d/custom-ubuntu.conf
 Raspbian: {}
 
 # os_family: RedHat


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [X] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
This fixes the defaults for Ubuntu 18.04.  
* The package to be installed should be 'wireguard' not 'wireguard-ubuntu'.
* When the wireguard application is installed using apt, it does not create an /etc/wireguard.d folder.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
```
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/99-master-address.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/99-master-address.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: jay-salt-test5
[DEBUG   ] Configuration file path: /etc/salt/minion
[WARNING ] Insecure logging configuration detected! Sensitive data may be logged.
[DEBUG   ] Grains refresh requested. Refreshing grains.
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/99-master-address.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/99-master-address.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] LazyLoaded zfs.is_supported
[DEBUG   ] Connecting to master. Attempt 1 of 1
[DEBUG   ] "saltprototype1.energytoolbase.com" Not an IP address? Assuming it is a hostname.
[DEBUG   ] Master URI: tcp://44.240.115.161:4506
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Generated random reconnect delay between '1000ms' and '11000ms' (5528)
[DEBUG   ] Setting zmq_reconnect_ivl to '5528ms'
[DEBUG   ] Setting zmq_reconnect_ivl_max to '11000ms'
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', 'clear')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[DEBUG   ] salt.crypt.get_rsa_pub_key: Loading public key
[DEBUG   ] Decrypting the current master AES key
[DEBUG   ] salt.crypt.get_rsa_key: Loading private key
[DEBUG   ] salt.crypt._get_key_with_evict: Loading private key
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion/minion.pem
[DEBUG   ] salt.crypt.get_rsa_pub_key: Loading public key
[DEBUG   ] Closing AsyncZeroMQReqChannel instance
[DEBUG   ] Connecting the Minion to the Master publish port, using the URI: tcp://44.240.115.161:4505
[DEBUG   ] salt.crypt.get_rsa_key: Loading private key
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion/minion.pem
[DEBUG   ] Determining pillar cache
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[DEBUG   ] salt.crypt.get_rsa_key: Loading private key
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion/minion.pem
[DEBUG   ] Closing AsyncZeroMQReqChannel instance
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] LazyLoaded state.apply
[DEBUG   ] LazyLoaded direct_call.execute
[DEBUG   ] LazyLoaded saltutil.is_running
[DEBUG   ] LazyLoaded grains.get
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[DEBUG   ] Gathering pillar data for state run
[DEBUG   ] Finished gathering pillar data for state run
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] LazyLoaded jinja.render
[DEBUG   ] LazyLoaded yaml.render
[DEBUG   ] Could not find file 'salt://wireguard.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/init.sls' to resolve 'salt://wireguard/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/init.sls' to resolve 'salt://wireguard/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/init.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/init.sls' using 'jinja' renderer: 0.00884318351746
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/init.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - .package
  - .config
  - .service

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'.package', u'.config', u'.service'])])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/init.sls' using 'yaml' renderer: 0.000373125076294
[DEBUG   ] Could not find file 'salt://wireguard/package.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/package/init.sls' to resolve 'salt://wireguard/package/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/package/init.sls' to resolve 'salt://wireguard/package/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/package/init.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/package/init.sls' using 'jinja' renderer: 0.00123405456543
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/package/init.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - .install

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'.install'])])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/package/init.sls' using 'yaml' renderer: 0.000436067581177
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/package/install.sls' to resolve 'salt://wireguard/package/install.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/package/install.sls' to resolve 'salt://wireguard/package/install.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/package/install.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[DEBUG   ] LazyLoaded config.get
[DEBUG   ] LazyLoaded grains.filter_by
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/package/install.sls' using 'jinja' renderer: 0.0967569351196
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/package/install.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

wireguard-package-install-pkg-installed:
  pkg.installed:
    - name: wireguard

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'wireguard-package-install-pkg-installed', OrderedDict([(u'pkg.installed', [OrderedDict([(u'name', u'wireguard')])])]))])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/package/install.sls' using 'yaml' renderer: 0.000405073165894
[DEBUG   ] Could not find file 'salt://wireguard/config.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/config/init.sls' to resolve 'salt://wireguard/config/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/config/init.sls' to resolve 'salt://wireguard/config/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/config/init.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/config/init.sls' using 'jinja' renderer: 0.000853061676025
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/config/init.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - .file

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'.file'])])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/config/init.sls' using 'yaml' renderer: 0.00031304359436
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/config/file.sls' to resolve 'salt://wireguard/config/file.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/config/file.sls' to resolve 'salt://wireguard/config/file.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/config/file.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/libtofs.jinja' to resolve 'salt://wireguard/libtofs.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/libtofs.jinja' to resolve 'salt://wireguard/libtofs.jinja'
[DEBUG   ] key: wireguard:tofs:path_prefix, ret: _|-
[DEBUG   ] key: wireguard:tofs:dirs:files, ret: _|-
[DEBUG   ] key: wireguard:tofs:files:wireguard-config-file-interface-wg0-config, ret: _|-
[DEBUG   ] key: wireguard:files_switch, ret: _|-
[DEBUG   ] key: config, ret: _|-
[DEBUG   ] key: config, ret: _|-
[DEBUG   ] key: wireguard:tofs:dirs:default, ret: _|-
[DEBUG   ] key: wireguard:tofs:dirs:default, ret: _|-
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/config/file.sls' using 'jinja' renderer: 0.114636898041
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/config/file.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - wireguard.package.install

wireguard-config-file-config-dir:
  file.directory:
    - name: /etc/wireguard
    - user: root
    - group: root
wireguard-config-file-mine-update:
  module.run:
    - name: mine.update
wireguard-config-file-interface-wg0-private-key:
  cmd.run:
    - umask: "077"
    - name: wg genkey > /etc/wireguard/wg0.priv
    - creates: /etc/wireguard/wg0.priv
    - require_in:
      - file: "wireguard-config-file-interface-wg0-config"

wireguard-config-file-interface-wg0-public-key:
  cmd.run:
    # Show public key for easier debugging
    - name: wg pubkey < /etc/wireguard/wg0.priv | tee /etc/wireguard/wg0.pub
    - creates: /etc/wireguard/wg0.pub
    - onchanges:
      - cmd: wireguard-config-file-interface-wg0-private-key
    - onchanges_in:
      - module: wireguard-config-file-mine-update

"wireguard-config-file-interface-wg0-config":
  file.managed:
    - name: /etc/wireguard/wg0.conf
    - source: 
      - salt://wireguard/files/config/wireguard.conf.jinja
      - salt://wireguard/files/config/wireguard.conf.jinja
      - salt://wireguard/files/default/wireguard.conf.jinja
      - salt://wireguard/files/default/wireguard.conf.jinja
    - mode: 600
    - user: root
    - group: root
    - makedirs: True
    - template: jinja
    - require:
      - file: wireguard-config-file-config-dir
      - sls: wireguard.package.install
    - context:
        interface_config: {"Interface": {"Address": "10.20.40.185", "ListenPort": 40000, "PostUp": "wg set %i private-key /etc/wireguard/wg0.priv && (true)"}, "Peers": {"blah": {"AllowedIPs": "10.20.0.0/16", "Endpoint": "home.pasonpowerint.com:40000", "PublicKey": "gQH7F3nz5hxwM1iPvH5Ue0Lxokrh/7/GXPcG5WITqF0="}}}

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'wireguard.package.install']), (u'wireguard-config-file-config-dir', OrderedDict([(u'file.directory', [OrderedDict([(u'name', u'/etc/wireguard')]), OrderedDict([(u'user', u'root')]), OrderedDict([(u'group', u'root')])])])), (u'wireguard-config-file-mine-update', OrderedDict([(u'module.run', [OrderedDict([(u'name', u'mine.update')])])])), (u'wireguard-config-file-interface-wg0-private-key', OrderedDict([(u'cmd.run', [OrderedDict([(u'umask', u'077')]), OrderedDict([(u'name', u'wg genkey > /etc/wireguard/wg0.priv')]), OrderedDict([(u'creates', u'/etc/wireguard/wg0.priv')]), OrderedDict([(u'require_in', [OrderedDict([(u'file', u'wireguard-config-file-interface-wg0-config')])])])])])), (u'wireguard-config-file-interface-wg0-public-key', OrderedDict([(u'cmd.run', [OrderedDict([(u'name', u'wg pubkey < /etc/wireguard/wg0.priv | tee /etc/wireguard/wg0.pub')]), OrderedDict([(u'creates', u'/etc/wireguard/wg0.pub')]), OrderedDict([(u'onchanges', [OrderedDict([(u'cmd', u'wireguard-config-file-interface-wg0-private-key')])])]), OrderedDict([(u'onchanges_in', [OrderedDict([(u'module', u'wireguard-config-file-mine-update')])])])])])), (u'wireguard-config-file-interface-wg0-config', OrderedDict([(u'file.managed', [OrderedDict([(u'name', u'/etc/wireguard/wg0.conf')]), OrderedDict([(u'source', [u'salt://wireguard/files/config/wireguard.conf.jinja', u'salt://wireguard/files/config/wireguard.conf.jinja', u'salt://wireguard/files/default/wireguard.conf.jinja', u'salt://wireguard/files/default/wireguard.conf.jinja'])]), OrderedDict([(u'mode', 600)]), OrderedDict([(u'user', u'root')]), OrderedDict([(u'group', u'root')]), OrderedDict([(u'makedirs', True)]), OrderedDict([(u'template', u'jinja')]), OrderedDict([(u'require', [OrderedDict([(u'file', u'wireguard-config-file-config-dir')]), OrderedDict([(u'sls', u'wireguard.package.install')])])]), OrderedDict([(u'context', OrderedDict([(u'interface_config', OrderedDict([(u'Interface', OrderedDict([(u'Address', u'10.20.40.185'), (u'ListenPort', 40000), (u'PostUp', u'wg set %i private-key /etc/wireguard/wg0.priv && (true)')])), (u'Peers', OrderedDict([(u'blah', OrderedDict([(u'AllowedIPs', u'10.20.0.0/16'), (u'Endpoint', u'home.pasonpowerint.com:40000'), (u'PublicKey', u'gQH7F3nz5hxwM1iPvH5Ue0Lxokrh/7/GXPcG5WITqF0=')]))]))]))]))])])]))])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/config/file.sls' using 'yaml' renderer: 0.00326108932495
[DEBUG   ] Could not find file 'salt://wireguard/service.sls' in saltenv 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/service/init.sls' to resolve 'salt://wireguard/service/init.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/service/init.sls' to resolve 'salt://wireguard/service/init.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/service/init.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/service/init.sls' using 'jinja' renderer: 0.000863790512085
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/service/init.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - .running

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'.running'])])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/service/init.sls' using 'yaml' renderer: 0.00029993057251
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/service/running.sls' to resolve 'salt://wireguard/service/running.sls'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/service/running.sls' to resolve 'salt://wireguard/service/running.sls'
[DEBUG   ] compile template: /var/cache/salt/minion/files/base/wireguard/service/running.sls
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/map.jinja' to resolve 'salt://wireguard/map.jinja'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/defaults.yaml' to resolve 'salt://wireguard/defaults.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osarchmap.yaml' to resolve 'salt://wireguard/osarchmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfamilymap.yaml' to resolve 'salt://wireguard/osfamilymap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osmap.yaml' to resolve 'salt://wireguard/osmap.yaml'
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/osfingermap.yaml' to resolve 'salt://wireguard/osfingermap.yaml'
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/service/running.sls' using 'jinja' renderer: 0.0813419818878
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/wireguard/service/running.sls:
# -*- coding: utf-8 -*-
# vim: ft=sls

include:
  - wireguard.config.file
wireguard-service-running-service-running-wg0:
  service.running:
    - name: wg-quick@wg0
    - enable: True
    - watch:
      - sls: wireguard.config.file
      - file: wireguard-config-file-interface-wg0-config

[DEBUG   ] Results of YAML rendering: 
OrderedDict([(u'include', [u'wireguard.config.file']), (u'wireguard-service-running-service-running-wg0', OrderedDict([(u'service.running', [OrderedDict([(u'name', u'wg-quick@wg0')]), OrderedDict([(u'enable', True)]), OrderedDict([(u'watch', [OrderedDict([(u'sls', u'wireguard.config.file')]), OrderedDict([(u'file', u'wireguard-config-file-interface-wg0-config')])])])])]))])
[PROFILE ] Time (in seconds) to render '/var/cache/salt/minion/files/base/wireguard/service/running.sls' using 'yaml' renderer: 0.000554084777832
[DEBUG   ] LazyLoaded pkg.install
[DEBUG   ] LazyLoaded pkg.installed
[DEBUG   ] Reading configuration from /etc/salt/minion
[DEBUG   ] Including configuration from '/etc/salt/minion.d/99-master-address.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/99-master-address.conf
[DEBUG   ] Including configuration from '/etc/salt/minion.d/_schedule.conf'
[DEBUG   ] Reading configuration from /etc/salt/minion.d/_schedule.conf
[DEBUG   ] Using cached minion ID from /etc/salt/minion_id: jay-salt-test5
[DEBUG   ] Could not LazyLoad boto3.assign_funcs: 'boto3.assign_funcs' is not available.
[DEBUG   ] Error loading module.boto3_elasticsearch: __init__ failed
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1664, in _load_module
    module_init(self.opts)
  File "/usr/lib/python2.7/dist-packages/salt/modules/boto3_elasticsearch.py", line 92, in __init__
    __utils__['boto3.assign_funcs'](__name__, 'es')
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1248, in __getitem__
    func = super(LazyLoader, self).__getitem__(item)
  File "/usr/lib/python2.7/dist-packages/salt/utils/lazy.py", line 108, in __getitem__
    raise KeyError(key)
KeyError: u'boto3.assign_funcs'
[DEBUG   ] key: ifttt.secret_key, ret: _|-
[DEBUG   ] key: ifttt:secret_key, ret: _|-
[DEBUG   ] key: pushbullet.api_key, ret: _|-
[DEBUG   ] key: pushbullet:api_key, ret: _|-
[DEBUG   ] Error loading module.swarm: __init__ failed
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1664, in _load_module
    module_init(self.opts)
  File "/usr/lib/python2.7/dist-packages/salt/modules/swarm.py", line 53, in __init__
    __context__['client'] = docker.from_env()
AttributeError: 'module' object has no attribute 'from_env'
[DEBUG   ] key: victorops.api_key, ret: _|-
[DEBUG   ] key: victorops:api_key, ret: _|-
[DEBUG   ] DSC: Only available on Windows systems
[DEBUG   ] Module PSGet: Only available on Windows systems
[DEBUG   ] Could not LazyLoad pkg.ex_mod_init: 'pkg.ex_mod_init' is not available.
[INFO    ] Running state [wireguard] at time 18:38:06.775476
[INFO    ] Executing state pkg.installed for [wireguard]
[DEBUG   ] Could not LazyLoad pkg.resolve_capabilities: 'pkg.resolve_capabilities' is not available.
[INFO    ] Executing command [u'dpkg-query', u'--showformat', u'${Status} ${Package} ${Version} ${Architecture}', u'-W'] in directory '/root'
[DEBUG   ] Could not LazyLoad pkg.check_db: 'pkg.check_db' is not available.
[INFO    ] The following packages would be installed/updated: wireguard
[INFO    ] Completed state [wireguard] at time 18:38:06.820479 (duration_in_ms=45.003)
[DEBUG   ] LazyLoaded file.directory
[INFO    ] Running state [/etc/wireguard] at time 18:38:06.824267
[INFO    ] Executing state file.directory for [/etc/wireguard]
[INFO    ] {u'/etc/wireguard': {u'directory': u'new'}}
[INFO    ] Completed state [/etc/wireguard] at time 18:38:06.825218 (duration_in_ms=0.951)
[DEBUG   ] LazyLoaded module.run
[DEBUG   ] LazyLoaded cmd.run
[INFO    ] Running state [wg genkey > /etc/wireguard/wg0.priv] at time 18:38:06.827539
[INFO    ] Executing state cmd.run for [wg genkey > /etc/wireguard/wg0.priv]
[INFO    ] Command "wg genkey > /etc/wireguard/wg0.priv" would have been executed
[INFO    ] Completed state [wg genkey > /etc/wireguard/wg0.priv] at time 18:38:06.828187 (duration_in_ms=0.646)
[INFO    ] Running state [/etc/wireguard/wg0.conf] at time 18:38:06.828851
[INFO    ] Executing state file.managed for [/etc/wireguard/wg0.conf]
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[DEBUG   ] In saltenv 'base', looking at rel_path 'wireguard/files/default/wireguard.conf.jinja' to resolve 'salt://wireguard/files/default/wireguard.conf.jinja'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/minion/files/base/wireguard/files/default/wireguard.conf.jinja' to resolve 'salt://wireguard/files/default/wireguard.conf.jinja'
[DEBUG   ] Jinja search path: [u'/var/cache/salt/minion/files/base']
[INFO    ] {u'newfile': u'/etc/wireguard/wg0.conf'}
[INFO    ] Completed state [/etc/wireguard/wg0.conf] at time 18:38:06.880190 (duration_in_ms=51.337)
[DEBUG   ] LazyLoaded service.running
[INFO    ] Running state [wg-quick@wg0] at time 18:38:06.881475
[INFO    ] Executing state service.running for [wg-quick@wg0]
[INFO    ] Executing command [u'systemctl', 'status', u'wg-quick@wg0.service', u'-n', u'0'] in directory '/root'
[DEBUG   ] stdout: * wg-quick@wg0.service - WireGuard via wg-quick(8) for wg0
   Loaded: loaded (/lib/systemd/system/wg-quick@.service; indirect; vendor preset: enabled)
   Active: active (exited) since Wed 2021-04-28 18:34:23 CDT; 3min 43s ago
     Docs: man:wg-quick(8)
           man:wg(8)
           https://www.wireguard.com/
           https://www.wireguard.com/quickstart/
           https://git.zx2c4.com/wireguard-tools/about/src/man/wg-quick.8
           https://git.zx2c4.com/wireguard-tools/about/src/man/wg.8
  Process: 21741 ExecStop=/usr/bin/wg-quick down wg0 (code=exited, status=0/SUCCESS)
  Process: 21760 ExecStart=/usr/bin/wg-quick up wg0 (code=exited, status=0/SUCCESS)
 Main PID: 21760 (code=exited, status=0/SUCCESS)
[INFO    ] Executing command [u'systemctl', 'is-active', u'wg-quick@wg0.service'] in directory '/root'
[DEBUG   ] stdout: active
[INFO    ] Executing command [u'systemctl', 'is-enabled', u'wg-quick@wg0.service'] in directory '/root'
[DEBUG   ] stdout: enabled
[INFO    ] The service wg-quick@wg0 is already running
[INFO    ] Completed state [wg-quick@wg0] at time 18:38:06.927898 (duration_in_ms=46.422)
[INFO    ] Running state [wg-quick@wg0] at time 18:38:06.928105
[INFO    ] Executing state service.mod_watch for [wg-quick@wg0]
[INFO    ] Executing command [u'systemctl', 'is-active', u'wg-quick@wg0.service'] in directory '/root'
[DEBUG   ] stdout: active
[DEBUG   ] LazyLoaded service.full_restart
[INFO    ] Service is set to be restarted
[INFO    ] Completed state [wg-quick@wg0] at time 18:38:06.941019 (duration_in_ms=12.912)
[DEBUG   ] File /var/cache/salt/minion/accumulator/140119817182928 does not exist, no need to cleanup
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506', u'aes')
[DEBUG   ] Initializing new AsyncAuth for (u'/etc/salt/pki/minion', u'jay-salt-test5', u'tcp://44.240.115.161:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://44.240.115.161:4506
[DEBUG   ] Trying to connect to: tcp://44.240.115.161:4506
[DEBUG   ] Closing AsyncZeroMQReqChannel instance
[DEBUG   ] LazyLoaded highstate.output
[DEBUG   ] LazyLoaded nested.output
[DEBUG   ] LazyLoaded nested.output
[DEBUG   ] Closing AsyncZeroMQReqChannel instance

local:
----------
          ID: wireguard-package-install-pkg-installed
    Function: pkg.installed
        Name: wireguard
      Result: None
     Comment: The following packages would be installed/updated: wireguard
     Started: 18:38:06.775476
    Duration: 45.003 ms
     Changes:
----------
          ID: wireguard-config-file-config-dir
    Function: file.directory
        Name: /etc/wireguard
      Result: None
     Comment: The following files will be changed:
              /etc/wireguard: directory - new
     Started: 18:38:06.824267
    Duration: 0.951 ms
     Changes:
              ----------
              /etc/wireguard:
                  ----------
                  directory:
                      new
----------
          ID: wireguard-config-file-interface-wg0-private-key
    Function: cmd.run
        Name: wg genkey > /etc/wireguard/wg0.priv
      Result: None
     Comment: Command "wg genkey > /etc/wireguard/wg0.priv" would have been executed
     Started: 18:38:06.827541
    Duration: 0.646 ms
     Changes:
----------
          ID: wireguard-config-file-interface-wg0-public-key
    Function: cmd.run
        Name: wg pubkey < /etc/wireguard/wg0.priv | tee /etc/wireguard/wg0.pub
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 18:38:06.828421
    Duration: 0.008 ms
     Changes:
----------
          ID: wireguard-config-file-mine-update
    Function: module.run
        Name: mine.update
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 18:38:06.828500
    Duration: 0.005 ms
     Changes:
----------
          ID: wireguard-config-file-interface-wg0-config
    Function: file.managed
        Name: /etc/wireguard/wg0.conf
      Result: None
     Comment: The file /etc/wireguard/wg0.conf is set to be changed
              Note: No changes made, actual changes may
              be different due to other states.
     Started: 18:38:06.828853
    Duration: 51.337 ms
     Changes:
              ----------
              newfile:
                  /etc/wireguard/wg0.conf
----------
          ID: wireguard-service-running-service-running-wg0
    Function: service.running
        Name: wg-quick@wg0
      Result: None
     Comment: Service is set to be restarted
     Started: 18:38:06.928107
    Duration: 12.912 ms
     Changes:

Summary for local
------------
Succeeded: 7 (unchanged=5, changed=2)
Failed:    0
------------
Total states run:     7
Total run time: 110.862 ms
```
### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


