### PR TITLE
fix(FreeBSD): fix interaction with wireguard service

### DIFF
--- a/wireguard/service/clean.sls
+++ b/wireguard/service/clean.sls
@@ -16,15 +16,21 @@ wireguard-service-clean-service-dead-{{ interface }}:
 {%- endif %}
 
 {%-  if grains['os_family'] == 'FreeBSD' %}
-wireguard-service-clean-service-dead:
-  service.dead:
+wireguard-service-clean-service-disabled:
+  service.disabled:
     - name: {{ wireguard.service.name }}
-    - sig: wireguard-go
-    - enable: False
+
+wireguard-service-clean-service-dead:
+  cmd.run:
+    - name: service {{ wireguard.service.name }} onestop
+    - onlyif: service {{ wireguard.service.name }} onestatus
+    - require:
+      - service: wireguard-service-clean-service-disabled
 
 wireguard-service-clean-sysrc-absent:
   sysrc.absent:
     - name: wireguard_interfaces
     - require:
-      - service: wireguard-service-clean-service-dead
+      - service: wireguard-service-clean-service-disabled
+      - cmd: wireguard-service-clean-service-dead
 {%- endif %}


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

`state apply wireguard.service.running` always resulted in an error:

```
----------                                                                                                                                 
          ID: wireguard-service-running-service-running                                                                                    
    Function: service.running                                                                                                              
        Name: wireguard                                                                                                                    
      Result: False                                                                                                                        
     Comment: Service wireguard is already enabled, and is dead                                                                            
     Started: 12:28:50.280340                                                                                                              
    Duration: 254.583 ms                                                                                                                   
     Changes:
```

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

`service wireguard status` just does not behave as other services. My old implementation just does not work any more with the standard implementation of FreeBSD.

Therefore I use a bit of shellout to handle the peculiarities.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

–

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
% salt --state-output=changes --state-verbose=False 'host' state.apply wireguard.service.running
host:
----------
          ID: wireguard-service-running-sysrc-managed
    Function: sysrc.managed
        Name: wireguard_interfaces
      Result: True
     Comment: The value of "wireguard_interfaces" was changed!
     Started: 13:47:29.407565
    Duration: 111.769 ms
     Changes:   
              ----------
              new:
                  ----------
                  /etc/rc.conf:
                      ----------
                      wireguard_interfaces:
                           wgos0
              old:
                  None
----------
          ID: wireguard-service-running-service-enabled
    Function: service.enabled
        Name: wireguard
      Result: True
     Comment: Service wireguard has been enabled, and is in the desired state
     Started: 13:47:29.520550
    Duration: 172.543 ms
     Changes:   
              ----------
              wireguard:
                  True
----------
          ID: wireguard-service-running-service-running-trigger
    Function: cmd.run
        Name: /bin/sh -c 'exit 0'
      Result: True
     Comment: Command "/bin/sh -c 'exit 0'" run
     Started: 13:47:29.693542
    Duration: 59.307 ms
     Changes:   
              ----------
              pid:
                  18361
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: wireguard-service-running-service-running
    Function: cmd.run
        Name: sh -c "service wireguard onerestart 0<&- >/dev/null 2>&1"
      Result: True
     Comment: Command "sh -c "service wireguard onerestart 0<&- >/dev/null 2>&1"" run
     Started: 13:47:29.754939
    Duration: 115.074 ms
     Changes:   
              ----------
              pid:
                  18367
              retcode:
                  0
              stderr:
              stdout:

Summary for host
-------------
Succeeded: 10 (changed=4)
Failed:     0
-------------
Total states run:     10
Total run time:    1.609 s
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


